### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   workflow_run:
@@ -6,8 +8,6 @@ on:
     branches: [main]
     types: 
       - completed
-
-
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build and Test
 
 on: [push]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
+name: Build and Test
 permissions:
   contents: read
-name: Build and Test
-
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/hunter-read/lfg-notify-bot/security/code-scanning/2](https://github.com/hunter-read/lfg-notify-bot/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and does not perform any write operations, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions. The change should be made at the top of the `.github/workflows/test.yml` file, after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
